### PR TITLE
Remove moment dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "bootstrap-vue": "2.21.2",
     "core-js": "3.17.3",
     "jquery": "3.6.0",
-    "moment": "2.29.1",
     "popper.js": "1.16.1",
     "qrcode.vue": "3.3.2",
     "vue": "3.2.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5963,11 +5963,6 @@ mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.5, mkdirp@~0.5.1:
   dependencies:
     minimist "^1.2.5"
 
-moment@2.29.1:
-  version "2.29.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
-  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
-
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"


### PR DESCRIPTION
We are not using this dependency. And to prevent that we accidentally do, let's remove it.
If we need a date library we should use alternatives: https://momentjs.com/docs/#/-project-status/